### PR TITLE
BUILDPACK_URL now deprecated

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ For a new app:
 
 For an existing app:
 
-    heroku config:set BUILDPACK_URL=https://github.com/thenovices/heroku-buildpack-scipy
+    heroku buildpacks:set https://github.com/thenovices/heroku-buildpack-scipy
 
 You must specify your exact desired version in `requirements.txt` (e.g.,
 `numpy==1.9.0`). If no version is specified, the latest version available will


### PR DESCRIPTION
Minor doc tweak for API change (`BUILDPACK_URL` now supposedly deprecated)
https://devcenter.heroku.com/articles/buildpacks#using-a-custom-buildpack
